### PR TITLE
Updates ChannelFactory to accept clientProvidedName parameter.

### DIFF
--- a/RabbitMQSimpleConnectionFactory/Library/ChannelFactory.cs
+++ b/RabbitMQSimpleConnectionFactory/Library/ChannelFactory.cs
@@ -20,10 +20,12 @@ namespace RabbitMQSimpleConnectionFactory.Library
         private IConnection _connection;
 
         private ConnectionSetting _connectionSetting;
+        private string _clientProvidedName;
 
-        public ChannelFactory(ConnectionSetting connectionConfig)
+        public ChannelFactory(ConnectionSetting connectionConfig, string clientProvidedName = null)
         {
             this._connectionSetting = connectionConfig;
+            this._clientProvidedName = clientProvidedName;
         }
 
         /// <summary>
@@ -60,7 +62,7 @@ namespace RabbitMQSimpleConnectionFactory.Library
                 {
                     if (_connection == null || !_connection.IsOpen)
                     {
-                        _connection = factory.CreateConnection();
+                        _connection = factory.CreateConnection(this._clientProvidedName);
                     }
                 }
             }
@@ -89,7 +91,7 @@ namespace RabbitMQSimpleConnectionFactory.Library
                 Protocol = Protocols.AMQP_0_9_1
             };
 
-            var connection = factory.CreateConnection();
+            var connection = factory.CreateConnection(this._clientProvidedName);
 
             return connection;
         }

--- a/RabbitMQSimpleConnectionFactory/Library/ConnectionPool.cs
+++ b/RabbitMQSimpleConnectionFactory/Library/ConnectionPool.cs
@@ -1,25 +1,39 @@
 ﻿using RabbitMQ.Client;
 using RabbitMQSimpleConnectionFactory.Entity;
+using System;
 using System.Collections.Concurrent;
 
-namespace RabbitMQSimpleConnectionFactory.Library {
+namespace RabbitMQSimpleConnectionFactory.Library
+{
 
-    public class ConnectionPool {
+    public class ConnectionPool
+    {
         private static ConcurrentDictionary<int, IModel> _pool;
         private static int _index;
         private static int _size;
         private static readonly object Sync = new object();
         private static ChannelFactory _channelFactory;
 
-        public ConnectionPool(int size, ConnectionSetting connectionSetting) {
+        public ConnectionPool(int size, ConnectionSetting connectionSetting)
+        {
             _size = size;
 
-            _channelFactory = new ChannelFactory(connectionSetting);
+            _channelFactory = new ChannelFactory(connectionSetting) ?? throw new ArgumentNullException(nameof(connectionSetting));
             Init(size);
         }
 
-        public IModel GetChannel() {
-            lock (Sync) {
+        public ConnectionPool(int size, ChannelFactory channelFactory)
+        {
+            _size = size;
+
+            _channelFactory = channelFactory ?? throw new ArgumentNullException(nameof(channelFactory));
+            Init(size);
+        }
+
+        public IModel GetChannel()
+        {
+            lock (Sync)
+            {
                 _index = (_index < _size) ? _index++ : _index = 0;
             }
 
@@ -27,21 +41,27 @@ namespace RabbitMQSimpleConnectionFactory.Library {
             return model;
         }
 
-        private void Close() {
-            for (var position = 0; position < _size; position++) {
-                if (_pool[_index].IsOpen) {
+        private void Close()
+        {
+            for (var position = 0; position < _size; position++)
+            {
+                if (_pool[_index].IsOpen)
+                {
                     _pool[_index].Close();
                 }
             }
         }
 
-        private void Init(int size) {
-            lock (Sync) {
+        private void Init(int size)
+        {
+            lock (Sync)
+            {
                 if (_pool != null) return;
 
                 _pool = new ConcurrentDictionary<int, IModel>();
 
-                for (var position = 0; position < size; position++) {
+                for (var position = 0; position < size; position++)
+                {
                     _pool.TryAdd(position, ConnectionPool._channelFactory.Create());
                 }
             }

--- a/RabbitMQSimpleConnectionFactory/RabbitMQSimpleConnectionFactory.csproj
+++ b/RabbitMQSimpleConnectionFactory/RabbitMQSimpleConnectionFactory.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
O que:
- Adiciona parâmetro clientProvidedName na ChannelFactory.
Por que:
- Para permitir que as conexões criadas no RabbitMQ sejam logadas com um nome amigável a fim de identificar problemas de desconexões.
Como:
- Criado parâmetro clientProvidedName no construtor da classe, que é repassado para o método CreateConnection.